### PR TITLE
Fixed build error when using LLVM

### DIFF
--- a/InAppSettings/InAppSettings.m
+++ b/InAppSettings/InAppSettings.m
@@ -54,7 +54,7 @@ static InAppSettings *sharedInstance = nil;
 
 - (id)init{
     InAppSettingsViewController *settings = [[InAppSettingsViewController alloc] init];
-    self = [[UINavigationController alloc] initWithRootViewController:settings];
+    self = (InAppSettingsModalViewController *)[[UINavigationController alloc] initWithRootViewController:settings];
     [settings addDoneButton];
     [settings release];
     return self;


### PR DESCRIPTION
Apparently LLVM (when building for Archiving) doesn't like that `[InAppSettingsModalViewController init]` sets self to a UINavigationController.
